### PR TITLE
Add assert and remove phpunit

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -6,7 +6,7 @@ composer install
 
 hh_client
 
-hhvm vendor/bin/phpunit tests/
+vendor/bin/hacktest tests/
 
 echo > .hhconfig
 hh_server --check $(pwd)

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,11 @@
   "description": "Unit test helpers for Facebook projects",
   "license": "MIT",
   "require-dev": {
-    "hhvm/hacktest": "dev-master"
+    "hhvm/hacktest": "^0.1"
   },
   "require": {
     "hhvm": "^3.23",
     "hhvm/hsl": "^3.26",
     "hhvm/hhvm-autoload": "^1.6"
-  },
-  "repositories": [
-     {
-         "type": "vcs",
-         "url":  "git@github.com:hhvm/hacktest.git"
-     }
-   ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,18 @@
   "name": "facebook/fbexpect",
   "description": "Unit test helpers for Facebook projects",
   "license": "MIT",
-  "autoload": {
-    "classmap": [ "src/" ],
-    "files": [
-      "src/expect.php",
-      "src/utils.php"
-    ]
+  "require-dev": {
+    "hhvm/hacktest": "dev-master"
   },
   "require": {
     "hhvm": "^3.23",
-    "phpunit/phpunit": "^5.7",
-    "91carriage/phpunit-hhi": "^5.7"
-  }
+    "hhvm/hsl": "^3.26",
+    "hhvm/hhvm-autoload": "^1.6"
+  },
+  "repositories": [
+     {
+         "type": "vcs",
+         "url":  "git@github.com:hhvm/hacktest.git"
+     }
+   ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,495 +1,29 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c21f152dae19aafb77f102c47fd93b19",
+    "content-hash": "095df3a7cd9d30ce9ebfa636054c84a6",
     "packages": [
         {
-            "name": "91carriage/phpunit-hhi",
-            "version": "5.7.4",
+            "name": "fredemmott/hack-error-suppressor",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://git.simon.geek.nz/91-carriage/phpunit-hhi.git",
-                "reference": "29e50b1130dc6d72266460f1f303ba1f24937a40"
-            },
-            "require": {
-                "hhvm": ">=3.24.3"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.7.15"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "*"
-            },
-            "suggest": {
-                "91carriage/dbunit-hhi": "HHI files for use with DbUnit"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.0.x-dev",
-                    "dev-phpunit-5.7": "5.7.x-dev",
-                    "dev-phpunit-5.6": "5.6.x-dev",
-                    "dev-phpunit-5.5": "5.5.x-dev",
-                    "dev-phpunit-5.4": "5.4.x-dev",
-                    "dev-phpunit-5.3": "5.3.x-dev",
-                    "dev-phpunit-5.2": "5.2.x-dev",
-                    "dev-phpunit-5.1": "5.1.x-dev",
-                    "dev-phpunit-5.0": "5.0.x-dev",
-                    "dev-phpunit-4.8": "4.8.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "HHI definitions for PHPUnit",
-            "homepage": "https://git.simon.geek.nz/91-carriage/phpunit-hhi",
-            "keywords": [
-                "hack",
-                "hhvm",
-                "phpunit",
-                "testing"
-            ],
-            "time": "2018-03-02T23:37:33+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "url": "https://github.com/fredemmott/hack-error-suppressor.git",
+                "reference": "cb145c771b50f4f4eeec8c9cac4740df3d486a12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/fredemmott/hack-error-suppressor/zipball/cb145c771b50f4f4eeec8c9cac4740df3d486a12",
+                "reference": "cb145c771b50f4f4eeec8c9cac4740df3d486a12",
                 "shasum": ""
             },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "time": "2017-10-19T19:58:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-07-14T14:27:02+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "1.7.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2018-04-18T13:57:24+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
-            },
-            "require-dev": {
-                "ext-xdebug": "^2.1.4",
+                "91carriage/phpunit-hhi": "^5.6",
                 "phpunit/phpunit": "^5.7"
             },
-            "suggest": {
-                "ext-xdebug": "^2.5.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2017-04-02T07:44:40+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "time": "2017-11-27T13:52:08+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
             "type": "library",
             "autoload": {
                 "classmap": [
@@ -498,887 +32,372 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "ISC"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "name": "Fred Emmott",
+                    "email": "fred@fredemmott.co.uk"
                 }
             ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "description": "Suppress HHVM's automatic conversion of typechecker errors to fatals.",
+            "time": "2017-05-02T03:07:37+00:00"
         },
         {
-            "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "name": "hhvm/hhvm-autoload",
+            "version": "v1.6.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "url": "https://github.com/hhvm/hhvm-autoload.git",
+                "reference": "2808fe06fa850532270c54155c0bdab1bf0f67da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/2808fe06fa850532270c54155c0bdab1bf0f67da",
+                "reference": "2808fe06fa850532270c54155c0bdab1bf0f67da",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "composer-plugin-api": "^1.0",
+                "fredemmott/hack-error-suppressor": "^1.0",
+                "hhvm": "^3.23"
+            },
+            "replace": {
+                "facebook/hhvm-autoload": "1.*"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-12-04T08:55:13+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "5.7.27",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
-            },
-            "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "91carriage/phpunit-hhi": "^5.5",
+                "facebook/fbexpect": "^1.1",
+                "phpunit/phpunit": "^5.5"
             },
             "bin": [
-                "phpunit"
+                "bin/hh-autoload"
             ],
-            "type": "library",
+            "type": "composer-plugin",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "5.7.x-dev"
-                }
+                "class": [
+                    "Facebook\\AutoloadMap\\ComposerPlugin"
+                ]
             },
             "autoload": {
                 "classmap": [
+                    "src/Writer.php",
                     "src/"
+                ],
+                "files": [
+                    "src/AutoloadMap.php",
+                    "src/Config.php",
+                    "src/TypeAssert.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2018-02-01T05:50:59+00:00"
+            "time": "2018-06-12T20:21:07+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "name": "hhvm/hsl",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "url": "https://github.com/hhvm/hsl.git",
+                "reference": "f43f027681402f0a6807325400a761106fa10274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/f43f027681402f0a6807325400a761106fa10274",
+                "reference": "f43f027681402f0a6807325400a761106fa10274",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "hhvm": "^3.27.0",
+                "hhvm/hhvm-autoload": "^1.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2017-06-30T09:13:00+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.0.0",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "1.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "time": "2017-01-29T09:50:25+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "1.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-05-22T07:24:03+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "time": "2016-11-26T07:53:53+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
-            },
-            "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "time": "2016-11-19T08:54:04+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "time": "2015-10-12T03:26:01+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v3.4.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/033cfa61ef06ee0847e056e530201842b6e926c3",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-04-08T08:21:29+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "description": "The Hack Standard Library",
+            "time": "2018-06-07T01:25:22+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "facebook/definition-finder",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/definition-finder.git",
+                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/56e423889c51d315970305d44f70f0a7b9947dc4",
+                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm": "^3.26.0",
+                "hhvm/hhast": "3.27.1",
+                "hhvm/hhvm-autoload": "^1.6",
+                "hhvm/hsl": "^3.26.0",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.1",
+                "facebook/fbexpect": "^1.0.0",
+                "hhvm/systemlib-extractor": "~1.0",
+                "phpunit/phpunit": "~5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "autoload_files.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Find definitions in PHP or Hack files. Useful for autoloaders.",
+            "homepage": "https://github.com/hhvm/definitions-finder",
+            "keywords": [
+                "autoload",
+                "definitions",
+                "hack",
+                "hhvm"
+            ],
+            "time": "2018-06-28T19:37:43+00:00"
+        },
+        {
+            "name": "facebook/fbmarkdown",
+            "version": "v1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/fbmarkdown.git",
+                "reference": "c5f64b57ce15509da665056b5a41b51dfaa3cad6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/fbmarkdown/zipball/c5f64b57ce15509da665056b5a41b51dfaa3cad6",
+                "reference": "c5f64b57ce15509da665056b5a41b51dfaa3cad6",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hhvm-autoload": "^1.5",
+                "hhvm/hsl": "^1.1|^3.26.0",
+                "hhvm/type-assert": "^3.1"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.7",
+                "facebook/fbexpect": "^0.4.0|^3.26.0",
+                "hhvm/hhast": "^1.0|^3.26.0",
+                "phpunit/phpunit": "~5.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Markdown parser and renderer for Hack",
+            "keywords": [
+                "facebook",
+                "gfm",
+                "hack",
+                "markdown"
+            ],
+            "time": "2018-06-12T22:07:37+00:00"
+        },
+        {
+            "name": "facebook/hh-apidoc",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hh-apidoc.git",
+                "reference": "10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hh-apidoc/zipball/10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f",
+                "reference": "10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/definition-finder": "^2.0.0",
+                "facebook/fbmarkdown": "^1.0",
+                "facebook/hh-clilib": "^1.0.0",
+                "hhvm": "^3.27.0",
+                "hhvm/hhast": "^3.26.0",
+                "hhvm/hsl": "^1.4|^3.26.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-29T16:31:51+00:00"
+        },
+        {
+            "name": "facebook/hh-clilib",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hh-clilib.git",
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/2772c82a8f5fc715d5a2fbe801563f36fdda9943",
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hsl": "^3.26",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1.0",
+                "hhvm/hhast": "^3.27.0",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-20T03:25:12+00:00"
+        },
+        {
+            "name": "hhvm/hacktest",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:hhvm/hacktest.git",
+                "reference": "483864c3def16eb4a5162086e2b59b301c69d2a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hacktest/zipball/483864c3def16eb4a5162086e2b59b301c69d2a9",
+                "reference": "483864c3def16eb4a5162086e2b59b301c69d2a9",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/definition-finder": "^2.0",
+                "facebook/hh-apidoc": "^0.1",
+                "facebook/hh-clilib": "^1.0",
+                "hhvm": "^3.27.0",
+                "hhvm/hhvm-autoload": "^1.6",
+                "hhvm/hsl": "^3.26",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.0.0",
+                "hhvm/hhast": "^3.27",
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "bin/hacktest"
+            ],
+            "type": "library",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Hack Test Library",
+            "support": {
+                "source": "https://github.com/hhvm/hacktest/tree/master",
+                "issues": "https://github.com/hhvm/hacktest/issues"
+            },
+            "time": "2018-07-18T17:07:07+00:00"
+        },
+        {
+            "name": "hhvm/hhast",
+            "version": "v3.27.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hhast.git",
+                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/8cd58881ccecaf81a0c330dd204f4e0089ef9104",
+                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/hh-clilib": "^1.1.1",
+                "hhvm": "^3.26.0",
+                "hhvm/hsl": "^1.0.0|^3.26.0",
+                "hhvm/type-assert": "^3.1"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1.0",
+                "facebook/hack-codegen": "~3.0.3",
+                "hhvm/hhvm-autoload": "^1.5",
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "bin/hhast-lint",
+                "bin/hhast-inspect"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-28T15:01:11+00:00"
+        },
+        {
+            "name": "hhvm/type-assert",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/type-assert.git",
+                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/9bbe7cac2ff831142d74203479e72046cbc932f8",
+                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm": "^3.23.0",
+                "hhvm/hhvm-autoload": "^1.4",
+                "hhvm/hsl": "^1.0|^3.26.0"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.1",
+                "facebook/fbexpect": "^0.4.0|^1.0.0",
+                "phpunit/phpunit": "~5.1"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Convert untyped data to typed data",
+            "keywords": [
+                "TypeAssert",
+                "hack"
+            ],
+            "time": "2018-05-09T18:23:07+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "hhvm/hacktest": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "095df3a7cd9d30ce9ebfa636054c84a6",
+    "content-hash": "7eb603d3db179739caef4e0c57f87884",
     "packages": [
         {
             "name": "fredemmott/hack-error-suppressor",
@@ -128,21 +128,21 @@
     "packages-dev": [
         {
             "name": "facebook/definition-finder",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/definition-finder.git",
-                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4"
+                "reference": "7607e61a0784786b1720e7b5cbda85f980f33d24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/56e423889c51d315970305d44f70f0a7b9947dc4",
-                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4",
+                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/7607e61a0784786b1720e7b5cbda85f980f33d24",
+                "reference": "7607e61a0784786b1720e7b5cbda85f980f33d24",
                 "shasum": ""
             },
             "require": {
                 "hhvm": "^3.26.0",
-                "hhvm/hhast": "3.27.1",
+                "hhvm/hhast": "^3.27.1",
                 "hhvm/hhvm-autoload": "^1.6",
                 "hhvm/hsl": "^3.26.0",
                 "hhvm/type-assert": "^3.2"
@@ -150,7 +150,6 @@
             "require-dev": {
                 "91carriage/phpunit-hhi": "~5.1",
                 "facebook/fbexpect": "^1.0.0",
-                "hhvm/systemlib-extractor": "~1.0",
                 "phpunit/phpunit": "~5.1"
             },
             "type": "library",
@@ -174,7 +173,7 @@
                 "hack",
                 "hhvm"
             ],
-            "time": "2018-06-28T19:37:43+00:00"
+            "time": "2018-07-20T22:51:05+00:00"
         },
         {
             "name": "facebook/fbmarkdown",
@@ -277,10 +276,10 @@
         },
         {
             "name": "hhvm/hacktest",
-            "version": "dev-master",
+            "version": "v0.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:hhvm/hacktest.git",
+                "url": "https://github.com/hhvm/hacktest.git",
                 "reference": "483864c3def16eb4a5162086e2b59b301c69d2a9"
             },
             "dist": {
@@ -308,28 +307,25 @@
                 "bin/hacktest"
             ],
             "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "The Hack Test Library",
-            "support": {
-                "source": "https://github.com/hhvm/hacktest/tree/master",
-                "issues": "https://github.com/hhvm/hacktest/issues"
-            },
             "time": "2018-07-18T17:07:07+00:00"
         },
         {
             "name": "hhvm/hhast",
-            "version": "v3.27.1",
+            "version": "v3.27.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhast.git",
-                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104"
+                "reference": "19b1fda576b0ff9323d997c7e837c919027ef921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhast/zipball/8cd58881ccecaf81a0c330dd204f4e0089ef9104",
-                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/19b1fda576b0ff9323d997c7e837c919027ef921",
+                "reference": "19b1fda576b0ff9323d997c7e837c919027ef921",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +350,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2018-06-28T15:01:11+00:00"
+            "time": "2018-07-17T15:35:27+00:00"
         },
         {
             "name": "hhvm/type-assert",
@@ -395,9 +391,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "hhvm/hacktest": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -1,0 +1,9 @@
+{
+    "roots": [
+        "src"
+    ],
+    "devRoots": [
+        "tests"
+    ],
+    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit colors="true">
+<phpunit colors="true" bootstrap="vendor/hh_autoload.php">
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
       <directory suffix=".php">src/</directory>

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -352,7 +352,7 @@ abstract class Assert {
       \is_array($haystack) ||
       (\is_object($haystack) && $haystack instanceof Traversable)
     ) {
-      if (new Constraint\TraversableContains($needle)->matches($haystack)) {
+      if ((new Constraint\TraversableContains($needle))->matches($haystack)) {
         return;
       }
     } elseif (\is_string($haystack)) {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -10,29 +10,310 @@
 
 namespace Facebook\FBExpect;
 
-abstract class Assert extends \PHPUnit\Framework\Assert {
+use namespace HH\Lib\Str;
+
+abstract class Assert {
+
+  public function assertSame($expected, $actual, string $message = ''): void {
+    if ($expected === $actual) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is the same as %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertNotSame(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($expected !== $actual) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is not the same as %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertEquals($expected, $actual, string $message = ''): void {
+    if ($actual == $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is equal to %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertEqualsWithDelta(
+    num $expected,
+    $actual,
+    float $delta,
+    string $message = '',
+  ): void {
+    if ($actual >= $expected - $delta && $actual <= $expected + $delta) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\n%s does not equal %f with delta %f",
+        $message,
+        $actual,
+        (float)$expected,
+        $delta,
+      ),
+    );
+  }
+
+  public function assertNotEquals(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($actual != $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is not equal to %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertTrue($condition, string $message = '') {
+    if ($condition === true) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is true",
+        $message,
+        \var_export($condition, true),
+      ),
+    );
+  }
+
+  public function assertFalse($condition, string $message = '') {
+    if ($condition === false) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is false",
+        $message,
+        \var_export($condition, true),
+      ),
+    );
+  }
+
+  public function assertNull($actual, string $message = '') {
+    if ($actual === null) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is null",
+        $message,
+        \var_export($actual, true),
+      ),
+    );
+  }
+
+  public function assertNotNull($actual, string $message = '') {
+    if ($actual !== null) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is not null",
+        $message,
+        \var_export($actual, true),
+      ),
+    );
+  }
+
+  public function assertEmpty($actual, string $message = '') {
+    if (empty($actual) == true) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is empty",
+        $message,
+        \var_export($actual, true),
+      ),
+    );
+  }
+
+  public function assertNotEmpty($actual, string $message = '') {
+    if (empty($actual) != true) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is not empty",
+        $message,
+        \var_export($actual, true),
+      ),
+    );
+  }
+
+  public function assertGreaterThan(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($actual > $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is greater than %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertLessThan(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($actual < $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is less than %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertGreaterThanOrEqual(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($actual >= $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is greater than or equal to %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertLessThanOrEqual(
+    $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if ($actual <= $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is less than or equal to %s",
+        $message,
+        \var_export($actual, true),
+        \var_export($expected, true),
+      ),
+    );
+  }
+
+  public function assertInstanceOf(
+    string $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if (!\class_exists($expected) && !\interface_exists($expected)) {
+      throw new InvalidArgumentException('Invalid class or interface name');
+    }
+    if ($actual instanceof $expected) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is an instance of %s",
+        $message,
+        \var_export($actual, true),
+        $expected,
+      ),
+    );
+  }
+
+  public function assertNotInstanceOf(
+    string $expected,
+    $actual,
+    string $message = '',
+  ): void {
+    if (!\class_exists($expected) && !\interface_exists($expected)) {
+      throw new InvalidArgumentException('Invalid class or interface name');
+    }
+    if (!($actual instanceof $expected)) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s is not an instance of %s",
+        $message,
+        \var_export($actual, true),
+        $expected,
+      ),
+    );
+  }
+
   /**
    * Asserts that a variable is of a given type
    */
   public function assertType(
     string $expected,
-    mixed $actual,
+    $actual,
     string $message = '',
   ): void {
     if (is_type($expected)) {
-      $constraint = new Constraint\IsType($expected);
+      if ((new Constraint\IsType($expected))->matches($actual)) {
+        return;
+      }
+      throw new ExpectationFailedException(
+        Str\format(
+          "%s\nFailed asserting that %s is type %s",
+          $message,
+          \var_export($actual, true),
+          $expected,
+        ),
+      );
     } else if (\class_exists($expected) || \interface_exists($expected)) {
-      $constraint = new \PHPUnit_Framework_Constraint_IsInstanceOf(
-        /* HH_IGNORE_ERROR[4110] is really a classname */ $expected,
-      );
-    } else {
-      /* HH_FIXME[2049] unbound name */
-      throw \PHPUnit\Util\InvalidArgumentHelper::factory(
-        1,
-        'class or interface name',
-      );
+      $this->assertInstanceOf($expected, $actual, $message);
     }
-    $this->assertThat($actual, $constraint, $message);
+    throw new InvalidArgumentException('Invalid type');
   }
 
   /**
@@ -40,24 +321,143 @@ abstract class Assert extends \PHPUnit\Framework\Assert {
    */
   public function assertNotType(
     string $expected,
-    mixed $actual,
+    $actual,
     string $message = '',
   ): void {
     if (is_type($expected)) {
-      $constraint = new Constraint\IsType($expected);
-    } else if (\class_exists($expected) || \interface_exists($expected)) {
-      $constraint = new \PHPUnit_Framework_Constraint_IsInstanceOf(
-        /* HH_IGNORE_ERROR[4110] is really a classname */ $expected,
+      if (!(new Constraint\IsType($expected))->matches($actual)) {
+        return;
+      }
+      throw new ExpectationFailedException(
+        Str\format(
+          "%s\nFailed asserting that %s is not type %s",
+          $message,
+          \var_export($actual, true),
+          $expected,
+        ),
       );
+    } else if (\class_exists($expected) || \interface_exists($expected)) {
+      $this->assertNotInstanceOf($expected, $actual, $message);
+    }
+    throw new InvalidArgumentException('Invalid type');
+  }
+
+  public function assertContains(
+    $needle,
+    $haystack,
+    string $message = '',
+    bool $ignoreCase = false,
+  ): void {
+    if (
+      \is_array($haystack) ||
+      (\is_object($haystack) && $haystack instanceof Traversable)
+    ) {
+      if (new Constraint\TraversableContains($needle)->matches($haystack)) {
+        return;
+      }
+    } elseif (\is_string($haystack)) {
+      if (!\is_string($needle)) {
+        throw new InvalidArgumentException(
+          'If haystack is string, needle must be string',
+        );
+      }
+      if ($ignoreCase) {
+        if (Str\contains_ci($haystack, $needle)) {
+          return;
+        }
+      } else if (Str\contains($haystack, $needle)) {
+        return;
+      }
     } else {
-      /* HH_FIXME[2049] unbound name */
-      throw \PHPUnit\Util\InvalidArgumentHelper::factory(
-        1,
-        'class or interface name',
+      throw new InvalidArgumentException(
+        'Haystack must be an array, traversable or string',
       );
     }
-    $constraint = new \PHPUnit_Framework_Constraint_Not($constraint);
-    $this->assertThat($actual, $constraint, $message);
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s contains %s",
+        $message,
+        \var_export($haystack, true),
+        \var_export($needle, true),
+      ),
+    );
+  }
+
+  public function assertNotContains(
+    $needle,
+    $haystack,
+    string $message = '',
+    bool $ignoreCase = false,
+  ): void {
+    if (
+      \is_array($haystack) ||
+      (\is_object($haystack) && $haystack instanceof Traversable)
+    ) {
+      if (!(new Constraint\TraversableContains($needle)->matches($haystack))) {
+        return;
+      }
+    } elseif (\is_string($haystack)) {
+      if (!\is_string($needle)) {
+        throw new InvalidArgumentException(
+          'If haystack is string, needle must be string',
+        );
+      }
+      if ($ignoreCase) {
+        if (!Str\contains_ci($haystack, $needle)) {
+          return;
+        }
+      } else if (!Str\contains($haystack, $needle)) {
+        return;
+      }
+    } else {
+      throw new InvalidArgumentException(
+        'Haystack must be an array, traversable or string',
+      );
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s does not contain %s",
+        $message,
+        \var_export($haystack, true),
+        \var_export($needle, true),
+      ),
+    );
+  }
+
+  public function assertRegExp(
+    string $expected,
+    string $actual,
+    string $message = '',
+  ) {
+    if (\preg_match($expected, $actual) === 1) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s matches PCRE pattern %s",
+        $message,
+        $actual,
+        $expected,
+      ),
+    );
+  }
+
+  public function assertNotRegExp(
+    string $expected,
+    string $actual,
+    string $message = '',
+  ) {
+    if (\preg_match($expected, $actual) === 0) {
+      return;
+    }
+    throw new ExpectationFailedException(
+      Str\format(
+        "%s\nFailed asserting that %s does not match PCRE pattern %s",
+        $message,
+        $actual,
+        $expected,
+      ),
+    );
   }
 
   public function assertSubset(
@@ -80,7 +480,7 @@ abstract class Assert extends \PHPUnit\Framework\Assert {
 
       if (is_any_array($value) || is_object($value)) {
         $this->assertSubset($value, $actual_value, $msg, $path.$part);
-        } else {
+      } else {
         $this->assertEquals($value, $actual_value, $msg."\nKey: $path$part");
       }
     }
@@ -131,7 +531,7 @@ abstract class Assert extends \PHPUnit\Framework\Assert {
    */
   public function assertIsSorted<Tv>(
     Traversable<Tv> $collection,
-    (function(Tv,Tv) : bool) $comparator,
+    (function(Tv, Tv): bool) $comparator,
     string $message = '',
   ): void {
     // Note: the way we maintain the pair of values to be compared may seem
@@ -161,13 +561,12 @@ abstract class Assert extends \PHPUnit\Framework\Assert {
         $failure_detail = \sprintf(
           'at pos %d, %s and %s are in the wrong order',
           $index,
-          /* HH_IGNORE_ERROR[2049] unbound name */
-          \PHPUnit\Util\Type::toString($pair[0]),
-          /* HH_IGNORE_ERROR[2049] unbound name */
-          \PHPUnit\Util\Type::toString($pair[1]),
+          \var_export($pair[0], true),
+          \var_export($pair[1], true),
         );
 
-        $this->fail($main_message . ': ' . $failure_detail);
+        throw
+          new ExpectationFailedException($main_message.': '.$failure_detail);
       }
 
       $index++;
@@ -191,13 +590,13 @@ abstract class Assert extends \PHPUnit\Framework\Assert {
    */
   public function assertIsSortedByKey<Tv>(
     Traversable<Tv> $collection,
-    (function(Tv) : mixed) $key_extractor,
+    (function(Tv): mixed) $key_extractor,
     string $message = '',
   ): void {
     $this->assertIsSorted(
       $collection,
       /* HH_FIXME[4240] unsafe comparison (PHPism) */
-      ($a,$b) ==> $key_extractor($a) <= $key_extractor($b),
+      ($a, $b) ==> $key_extractor($a) <= $key_extractor($b),
       $message,
     );
   }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -393,7 +393,7 @@ abstract class Assert {
       \is_array($haystack) ||
       (\is_object($haystack) && $haystack instanceof Traversable)
     ) {
-      if (!(new Constraint\TraversableContains($needle)->matches($haystack))) {
+      if (!(new Constraint\TraversableContains($needle))->matches($haystack)) {
         return;
       }
     } elseif (\is_string($haystack)) {

--- a/src/Constraint/IsType.php
+++ b/src/Constraint/IsType.php
@@ -10,31 +10,41 @@
 
 namespace Facebook\FBExpect\Constraint;
 
-class IsType extends \PHPUnit_Framework_Constraint_IsType {
-  const type TPredicate = (function(mixed):bool);
+use function Facebook\FBExpect\is_iterable;
 
-  public function __construct(string $type) {
-    foreach (self::getExtraTypes() as $extra => $_pred) {
-      /* HH_IGNORE_ERROR[4053] types prop not in HHI*/
-      $this->types[$extra] = true;
-    }
-    parent::__construct($type);
-  }
+class IsType {
+  const type TPredicate = (function(mixed): bool);
+  public function __construct(private string $expectedType) {}
 
-  public function matches(mixed $other): bool {
-    $extra = self::getExtraTypes();
-    if ($extra->containsKey($this->type)) {
-      $predicate = $extra->at($this->type);
-      return $predicate($other);
-    }
-    return parent::matches($other);
-  }
-
-  protected static function getExtraTypes(): ImmMap<string, self::TPredicate> {
+  public static function getTypes(): ImmMap<string, self::TPredicate> {
     return ImmMap {
+      'numeric' => ($x ==> \is_numeric($x)),
+      'integer' => ($x ==> \is_int($x)),
+      'int' => ($x ==> \is_int($x)),
+      'double' => ($x ==> \is_float($x)),
+      'float' => ($x ==> \is_float($x)),
+      'real' => ($x ==> \is_float($x)),
+      'string' => ($x ==> \is_string($x)),
+      'boolean' => ($x ==> \is_bool($x)),
+      'bool' => ($x ==> \is_bool($x)),
+      'null' => ($x ==> $x === null),
+      'array' => ($x ==> \is_array($x)),
+      'object' => ($x ==> \is_object($x)),
+      'resource' => (
+        $x ==> \is_resource($x) || \is_string(@\get_resource_type($x))
+      ),
+      'scalar' => ($x ==> \is_scalar($x)),
+      'callable' => ($x ==> \is_callable($x)),
+      'iterable' => ($x ==> is_iterable($x)),
       'vec' => ($x ==> is_vec($x)),
       'dict' => ($x ==> is_dict($x)),
       'keyset' => ($x ==> is_keyset($x)),
     };
+  }
+
+  public function matches(mixed $other): bool {
+    $types = self::getTypes();
+    $predicate = $types->at($this->expectedType);
+    return $predicate($other);
   }
 }

--- a/src/Constraint/TraversableContains.php
+++ b/src/Constraint/TraversableContains.php
@@ -1,0 +1,28 @@
+<?hh
+
+namespace Facebook\FBExpect\Constraint;
+
+class TraversableContains {
+
+  public function __construct(private $value) {}
+
+  public function matches($other): bool {
+    if ($other instanceof \SplObjectStorage) {
+      return $other->contains($this->value);
+    }
+    if (\is_object($this->value)) {
+      foreach ($other as $element) {
+        if ($element === $this->value) {
+          return true;
+        }
+      }
+      return false;
+    }
+    foreach ($other as $element) {
+      if ($element == $this->value) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/Exception/ExpectationFailedException.php
+++ b/src/Exception/ExpectationFailedException.php
@@ -1,0 +1,5 @@
+<?hh // strict
+
+namespace Facebook\FBExpect;
+
+final class ExpectationFailedException extends \RuntimeException {}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,5 @@
+<?hh // strict
+
+namespace Facebook\FBExpect;
+
+final class InvalidArgumentException extends \RuntimeException {}

--- a/src/ExpectObj.php
+++ b/src/ExpectObj.php
@@ -43,9 +43,9 @@ class ExpectObj<T> extends Assert {
    * Float comparison can give false positives - this will only error if $actual
    * and $expected are not within $delta of each other.
    */
-  public function toEqualWithDelta($expected, float $delta, string $msg = '', ...): void {
+  public function toEqualWithDelta(num $expected, float $delta, string $msg = '', ...): void {
     $msg = \vsprintf($msg, \array_slice(\func_get_args(), 3));
-    $this->assertEquals($expected, $this->var, $msg, $delta);
+    $this->assertEqualsWithDelta($expected, $this->var, $delta, $msg);
   }
 
   public function toAlmostEqual($expected, string $msg = '', ...): void {
@@ -191,7 +191,7 @@ class ExpectObj<T> extends Assert {
   }
 
   /**
-   * Assert: For strings, strpos($actual, $needle) !== false
+   * Assert: For strings, Str\contains($actual, $needle) !== false
    *         For containers (array, Map, Set, etc) or objects which implement
    *         Traversable, iterate through $actual and see if any element ==
    *         $needle.
@@ -372,7 +372,7 @@ class ExpectObj<T> extends Assert {
   }
 
   /**
-   * Assert: For strings, strpos($actual, $needle) === false
+   * Assert: For strings, Str\contains($actual, $needle) !== false
    *         For containers (array, Map, Set, etc) or objects which implement
    *         Traversable, iterate through $actual and make sure there is no
    *         element for which $element == $needle.
@@ -497,7 +497,7 @@ class ExpectObj<T> extends Assert {
       $this->tryCallWithArgsReturnException($args, $exception_class);
 
     if (!$exception) {
-      $this->fail(
+      throw new \Exception(
         "$desc: Expected exception $exception_class wasn't thrown"
       );
     }

--- a/src/utils.php
+++ b/src/utils.php
@@ -34,23 +34,10 @@ function print_type(mixed $value): string {
   return \gettype($value);
 }
 
-function is_type(string $value): bool {
-  switch ($value) {
-    case 'vec':
-    case 'dict':
-    case 'keyset':
-      return true;
-    default:
-      /* HH_FIXME[2049] unbound name */
-      if (\class_exists(\PHPUnit_Util_Type::class)) {
-        // PHPUnit 5
-      /* HH_FIXME[2049] unbound name */
-        return \PHPUnit_Util_Type::isType($value);
-      } else {
-        // PHPUnit 6
-      /* HH_FIXME[2049] unbound name */
-      /* HH_FIXME[4107] unbound name */
-        return \PHPUnit\Util\Type\isType($value);
-      }
-  }
+function is_iterable(mixed $value): bool {
+  return is_array($value) || (is_object($value) && ($value instanceof Traversable));
+}
+
+function is_type(mixed $value): bool {
+  return Constraint\IsType::getTypes()->containsKey($value);
 }


### PR DESCRIPTION
I apologize in advance -- this diff is huge but all of these pieces need to be in place simultaneously in order to remove PHPUnit as a dependency entirely.

- PHPUnit is gone! Using HackTest to run tests
- Most of the logic for asserts is from PHPUnit, so nothing too special
- Added hh_autoload
- Added custom exception classes
- Removed one test that used toEqualWithDelta with arrays (restrict to num)

TODO (in another PR):
- Use hacktest in travis (this travis build will fail)
- Update README

Once this lands I can:
- Remove PHPUnit as a dependency from HackTest
- Check for my custom exceptions (rather than the PHPUnit versions) in external version of HackTest (www has its own version of expect)
- Remove PHPUnit from HSL 
- Submit diff to refactor HSL to use HackTest (basically ready, waiting for this)
- After above, update all three repos' (HackTest, HSL, FBExpect) composer.lock so that PHPUnit stuff doesn't show up anymore