### PR TITLE
Better output (diff) for strings that are not the same

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "hhvm": "^3.28",
     "hhvm/hsl": "^3.26",
     "hhvm/hhvm-autoload": "^1.6",
-    "facebook/difflib": "^0.1.0"
+    "facebook/difflib": "^0.2.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require": {
     "hhvm": "^3.28",
     "hhvm/hsl": "^3.26",
-    "hhvm/hhvm-autoload": "^1.6"
+    "hhvm/hhvm-autoload": "^1.6",
+    "facebook/difflib": "^0.1.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce2205cf913315f0c23c522b908fa1d0",
+    "content-hash": "b429513bc15d1b8300814f0df709a6df",
     "packages": [
+        {
+            "name": "facebook/difflib",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/difflib.git",
+                "reference": "6c3132642b8b8a691875c5bc9ddfd00f851ccd8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/difflib/zipball/6c3132642b8b8a691875c5bc9ddfd00f851ccd8c",
+                "reference": "6c3132642b8b8a691875c5bc9ddfd00f851ccd8c",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hsl": "^3.28"
+            },
+            "require-dev": {
+                "hhvm/hhast": "^3.28"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-09-05T19:26:26+00:00"
+        },
         {
             "name": "hhvm/hhvm-autoload",
             "version": "1.6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b429513bc15d1b8300814f0df709a6df",
+    "content-hash": "c44a8618d2fd0f77a869cbcde78d1b65",
     "packages": [
         {
             "name": "facebook/difflib",
-            "version": "v0.1",
+            "version": "v0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/difflib.git",
-                "reference": "6c3132642b8b8a691875c5bc9ddfd00f851ccd8c"
+                "reference": "2066396b8499ddc7d5a9436322c493e55379818b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/difflib/zipball/6c3132642b8b8a691875c5bc9ddfd00f851ccd8c",
-                "reference": "6c3132642b8b8a691875c5bc9ddfd00f851ccd8c",
+                "url": "https://api.github.com/repos/hhvm/difflib/zipball/2066396b8499ddc7d5a9436322c493e55379818b",
+                "reference": "2066396b8499ddc7d5a9436322c493e55379818b",
                 "shasum": ""
             },
             "require": {
@@ -31,7 +31,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2018-09-05T19:26:26+00:00"
+            "time": "2018-09-06T17:19:19+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -11,6 +11,7 @@
 namespace Facebook\FBExpect;
 
 use namespace HH\Lib\Str;
+use type Facebook\DiffLib\StringDiff;
 
 abstract class Assert {
 
@@ -18,6 +19,17 @@ abstract class Assert {
     if ($expected === $actual) {
       return;
     }
+
+    if ($expected is string && $actual is string) {
+      throw new ExpectationFailedException(
+        Str\format(
+          "%s\nFailed asserting that two strings are the same:\n%s\n",
+          $message,
+          StringDiff::lines($expected, $actual)->getUnifiedDiff(),
+        ),
+      );
+    }
+
     throw new ExpectationFailedException(
       Str\format(
         "%s\nFailed asserting that %s is the same as %s",

--- a/tests/ExpectObjTest.php
+++ b/tests/ExpectObjTest.php
@@ -381,4 +381,14 @@ final class ExpectObjTest extends HackTestCase {
     $x = expect($x)->toNotBeNull();
     expect($x->getMessage())->toBeSame('foo');
   }
+
+  public function testDifferingStringOutput(): void {
+    try {
+      expect("a\nb\nd\n")->toBeSame("a\nb\nc\n");
+    } catch (ExpectationFailedException $e) {
+      expect($e->getMessage())->toContain(" a\n b\n-c\n+d\n");
+      return;
+    }
+    self::fail("Should have thrown an exception");
+  }
 }


### PR DESCRIPTION
fixes hhvm/hacktest#38

Test Plan:

New test case. Dumping the full error message gets me this:

```
Failed asserting that two strings are the same:
@@ -1,4 +1,4 @@
 a
 b
-c
+d

```