### PR TITLE
Add support for type checking Container and KeyedContainer.

### DIFF
--- a/src/Constraint/IsType.php
+++ b/src/Constraint/IsType.php
@@ -39,6 +39,8 @@ class IsType {
       'vec' => ($x ==> ($x is vec<_>)),
       'dict' => ($x ==> ($x is dict<_, _>)),
       'keyset' => ($x ==> ($x is keyset<_>)),
+      'Container' => ($x ==> ($x is Container<_>)),
+      'KeyedContainer' => ($x ==> ($x is KeyedContainer<_, _>)),
     };
   }
 

--- a/tests/ExpectObjTest.php
+++ b/tests/ExpectObjTest.php
@@ -52,6 +52,10 @@ final class ExpectObjTest extends HackTest {
     expect(vec[])->toNotBeType('array');
     expect(dict[])->toBeType('dict');
     expect(keyset[])->toBeType('keyset');
+    expect(Set {})->toBeType('Container');
+    // vec[] is keyed by int type.
+    expect(vec[])->toBeType('KeyedContainer');
+    expect(dict[])->toBeType('KeyedContainer');
     expect(array(1, 2, 3))->toContain(2);
     expect(array(1, 2, 3))->toNotContain(7);
 


### PR DESCRIPTION
a function might return a `KeyedContainer` which doesn't have to be a `dict[]`, `vec[]` or a specific Collection.
in this case using `KeyedContainer` in testing is more appropriate.
same goes for `Container` type.