### PR TITLE
Undeprecate toEqual / toNotEqual

### DIFF
--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -28,7 +28,7 @@ class ExpectObj<T> extends Assert {
     string $msg = '',
     mixed ...$args
   ): void {
-    $this->toBePHPEqual($expected, $msg, ...$args);
+    $this->toBeSame($expected, $msg, ...$args);
   }
 
   /**
@@ -361,7 +361,7 @@ class ExpectObj<T> extends Assert {
     string $msg = '',
     mixed ...$args
   ): void {
-    $this->toNotBePHPEqual($expected, $msg, ...$args);
+    $this->toNotBeSame($expected, $msg, ...$args);
   }
 
   public function toNotBePHPEqual(

--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -23,6 +23,11 @@ class ExpectObj<T> extends Assert {
    *
    */
 
+  /**
+   * Asserts: $actual === $expected
+   * Note:    Two objects are considered the same if they reference the same
+   *          instance
+   */
   public function toEqual(
     mixed $expected,
     string $msg = '',
@@ -356,6 +361,11 @@ class ExpectObj<T> extends Assert {
    **************************************
    **************************************/
 
+  /**
+   * Asserts: $actual !== $expected
+   * Note:    Two objects are considered the same if they reference the same
+   *          instance
+   */
   public function toNotEqual(
     mixed $expected,
     string $msg = '',

--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -23,7 +23,6 @@ class ExpectObj<T> extends Assert {
    *
    */
 
-  <<__Deprecated("Use toBeSame() or toBePHPEqual()")>>
   public function toEqual(
     mixed $expected,
     string $msg = '',
@@ -357,7 +356,6 @@ class ExpectObj<T> extends Assert {
    **************************************
    **************************************/
 
-  <<__Deprecated("Use toNotBeSame() or toNotBePHPEqual()")>>
   public function toNotEqual(
     mixed $expected,
     string $msg = '',


### PR DESCRIPTION
These functions are back in style now, apparently.