### PR TITLE
Use toHaveSameShapeAs to compare shape, array and dicts

### DIFF
--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -292,14 +292,13 @@ class ExpectObj<T> extends Assert {
     string $msg = '',
     mixed ...$args
   ): void {
-    $expected = $expected as shape(...);
     $msg = \vsprintf($msg, $args);
 
     $value = $this->var;
     /* HH_FIXME[4110] KeyedContainer<_, _> always has arraykey keys */
     $this->assertKeyAndValueEquals(
       $expected as KeyedContainer<_, _>,
-      \is_array($value) ? $value : [],
+      $value as KeyedContainer<_, _>,
       $msg,
     );
   }

--- a/tests/ExpectObjTest.hack
+++ b/tests/ExpectObjTest.hack
@@ -393,6 +393,7 @@ final class ExpectObjTest extends HackTest {
         );
       },
     )->notToThrow();
+
     expect(
       () ==> {
         expect(
@@ -407,6 +408,42 @@ final class ExpectObjTest extends HackTest {
             'b' => 3,
             'c' => 5,
           ),
+        );
+      },
+    )->toThrow(ExpectationFailedException::class);
+
+    expect(
+      () ==> {
+        expect(
+          array(
+            'a' => 5,
+            'b' => 4,
+            'c' => 3,
+          ),
+        )->toHaveSameShapeAs(
+          array(
+            'a' => 4,
+            'b' => 3,
+            'c' => 5,
+          ),
+        );
+      },
+    )->toThrow(ExpectationFailedException::class);
+
+    expect(
+      () ==> {
+        expect(
+          dict[
+            'a' => 5,
+            'b' => 4,
+            'c' => 3,
+          ],
+        )->toHaveSameShapeAs(
+          dict[
+            'a' => 4,
+            'b' => 3,
+            'c' => 5,
+          ],
         );
       },
     )->toThrow(ExpectationFailedException::class);

--- a/tests/ExpectObjTest.hack
+++ b/tests/ExpectObjTest.hack
@@ -321,6 +321,44 @@ final class ExpectObjTest extends HackTest {
         );
       },
     )->notToThrow();
+
+    // two arrays
+    expect(
+      () ==> {
+        expect(
+          array(
+            'a' => 5,
+            'b' => 4,
+            'c' => 3,
+          ),
+        )->toHaveSameShapeAs(
+          array(
+            'b' => 4,
+            'c' => 3,
+            'a' => 5,
+          ),
+        );
+      },
+    )->notToThrow();
+
+    // two dicts
+    expect(
+      () ==> {
+        expect(
+          dict[
+            'a' => 5,
+            'b' => 4,
+            'c' => 3,
+          ],
+        )->toHaveSameShapeAs(
+          dict[
+            'b' => 4,
+            'c' => 3,
+            'a' => 5,
+          ],
+        );
+      },
+    )->notToThrow();
   }
 
   public function testToHaveSameContentAsSuccess(): void {


### PR DESCRIPTION
We often run into the case where we want to compare two dicts that have the same contents but different orders. Currently this would hit the is_array() call inside toHaveSameShapeAs that ultimately ends up failing the assertion.

This PR removes that restriction. Added some tests to see that it works for shape, array and dicts.