### PR TITLE
Don't print both actual and expected if `toNotBeSame()` fails

### DIFF
--- a/src/Assert.hack
+++ b/src/Assert.hack
@@ -54,10 +54,9 @@ abstract class Assert {
     }
     throw new ExpectationFailedException(
       Str\format(
-        "%s\nFailed asserting that %s is not the same as %s",
+        "%s\nFailed asserting that values differed; both are %s",
         $message,
         \var_export($actual, true),
-        \var_export($expected, true),
       ),
     );
   }


### PR DESCRIPTION
... because they're the same.