### PR TITLE
Remove the need to do an array cast

### DIFF
--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -236,7 +236,11 @@ class ExpectObj<T> extends Assert {
     mixed ...$args
   ): void where T as Traversable<TVal> {
     $msg = \vsprintf($msg, $args);
-    $this->assertContains($needle, not_hack_array($this->var), $msg);
+    $this->assertContains(
+      $needle,
+      self::hackArraysToDVArrays($this->var),
+      $msg,
+    );
   }
 
   /**
@@ -460,7 +464,11 @@ class ExpectObj<T> extends Assert {
     mixed ...$args
   ): void where T as Traversable<TVal> {
     $msg = \vsprintf($msg, $args);
-    $this->assertNotContains($expected, not_hack_array($this->var), $msg);
+    $this->assertNotContains(
+      $expected,
+      self::hackArraysToDVArrays($this->var),
+      $msg,
+    );
   }
 
   /**
@@ -472,7 +480,7 @@ class ExpectObj<T> extends Assert {
     mixed ...$args
   ): void where T = string {
     $msg = \vsprintf($msg, $args);
-    $this->assertNotContains($expected, not_hack_array($this->var), $msg);
+    $this->assertNotContains($expected, $this->var, $msg);
   }
 
   /**
@@ -607,5 +615,15 @@ class ExpectObj<T> extends Assert {
     }
 
     return null;
+  }
+
+  private static function hackArraysToDVArrays(mixed $maybe_array): mixed {
+    return $maybe_array is vec<_>
+      ? varray($maybe_array)
+      : (
+          $maybe_array is dict<_, _> || $maybe_array is keyset<_>
+            ? darray($maybe_array)
+            : $maybe_array
+        );
   }
 }

--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -10,8 +10,7 @@
 namespace Facebook\FBExpect;
 
 class ExpectObj<T> extends Assert {
-  public function __construct(private T $var) {
-  }
+  public function __construct(private T $var) {}
 
   /**************************************
    **************************************
@@ -236,11 +235,7 @@ class ExpectObj<T> extends Assert {
     mixed ...$args
   ): void where T as Traversable<TVal> {
     $msg = \vsprintf($msg, $args);
-    $this->assertContains(
-      $needle,
-      self::hackArraysToDVArrays($this->var),
-      $msg,
-    );
+    $this->assertContains($needle, $this->var, $msg);
   }
 
   /**
@@ -464,11 +459,7 @@ class ExpectObj<T> extends Assert {
     mixed ...$args
   ): void where T as Traversable<TVal> {
     $msg = \vsprintf($msg, $args);
-    $this->assertNotContains(
-      $expected,
-      self::hackArraysToDVArrays($this->var),
-      $msg,
-    );
+    $this->assertNotContains($expected, $this->var, $msg);
   }
 
   /**
@@ -615,15 +606,5 @@ class ExpectObj<T> extends Assert {
     }
 
     return null;
-  }
-
-  private static function hackArraysToDVArrays(mixed $maybe_array): mixed {
-    return $maybe_array is vec<_>
-      ? varray($maybe_array)
-      : (
-          $maybe_array is dict<_, _> || $maybe_array is keyset<_>
-            ? darray($maybe_array)
-            : $maybe_array
-        );
   }
 }

--- a/src/utils.hack
+++ b/src/utils.hack
@@ -20,8 +20,7 @@ function is_any_array(mixed $value): bool {
 
 function not_hack_array(mixed $value): mixed {
   if (is_any_array($value) && !\is_array($value)) {
-    /* HH_IGNORE_ERROR[4007] sketchy array cast */
-    return (array) $value;
+    return varray($value as Traversable<_>);
   }
   return $value;
 }

--- a/src/utils.hack
+++ b/src/utils.hack
@@ -18,13 +18,6 @@ function is_any_array(mixed $value): bool {
   );
 }
 
-function not_hack_array(mixed $value): mixed {
-  if (is_any_array($value) && !\is_array($value)) {
-    return varray($value as Traversable<_>);
-  }
-  return $value;
-}
-
 function print_type(mixed $value): string {
   if (\is_object($value)) {
     return \get_class($value);


### PR DESCRIPTION
This function seems like it wants to avoid `dict<_, _>` `vec<_>` and `keyset<_>`.
This is where it came from and where it is still used until this day: https://github.com/hhvm/fbexpect/commit/76be22ec078e8977befa7420f0a9cb52c8335e84