### PR TITLE
Some general cleanup:

### DIFF
--- a/src/Assert.hack
+++ b/src/Assert.hack
@@ -541,7 +541,7 @@ abstract class Assert {
         $actual_value = idx($actual, $key ?as arraykey);
         $part = '['.\var_export($key, true).']';
       } else if (\is_object($actual)) {
-        $actual_value = /* HH_FIXME[2011] */ $actual->$key;
+        $actual_value = /* HH_FIXME[2011] Dynamic property access */ $actual->$key;
         $part = "->".$key;
       } else {
         $actual_value = null;
@@ -678,7 +678,6 @@ abstract class Assert {
     $out = dict[];
     foreach ($arr as $k => $v) {
       if ($v is KeyedContainer<_, _>) {
-        /* HH_FIXME[4110] KeyedContainer<_, _> always has arraykey keys */
         $v = self::sortArrayRecursive($v);
       }
       $out[$k as arraykey] = $v;

--- a/src/Constraint/TraversableContains.hack
+++ b/src/Constraint/TraversableContains.hack
@@ -16,7 +16,10 @@ class TraversableContains {
 
   public function matches(Traversable<mixed> $other): bool {
     if ($other is \SplObjectStorage<_, _>) {
-      return $other->contains(/* HH_FIXME[4110] */ $this->value);
+      return $other->contains(
+        /* HH_FIXME[4110] SplObjectStorage<TObj, Tv>->contains can not be refined enough */ 
+        $this->value,
+      );
     }
     if (\is_object($this->value)) {
       foreach ($other as $element) {

--- a/src/Constraint/TraversableContains.hack
+++ b/src/Constraint/TraversableContains.hack
@@ -17,7 +17,7 @@ class TraversableContains {
   public function matches(Traversable<mixed> $other): bool {
     if ($other is \SplObjectStorage<_, _>) {
       return $other->contains(
-        /* HH_FIXME[4110] SplObjectStorage<TObj, Tv>->contains can not be refined enough */ 
+        /* HH_FIXME[4110] SplObjectStorage<TObj, Tv>->contains can not be refined enough */
         $this->value,
       );
     }

--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -197,7 +197,9 @@ class ExpectObj<T> extends Assert {
     $msg = \vsprintf($msg, $args);
     $obj = $this->var;
     $this->assertInstanceOf($class_or_interface, $obj, $msg);
-    return /* HH_IGNORE_ERROR[4110] */ $obj;
+    return
+      /* HH_IGNORE_ERROR[4110] Typechecker can't understand assertInstanceOf */
+      $obj;
   }
 
   // Asserts: $actual matches $expected regular expression
@@ -304,7 +306,6 @@ class ExpectObj<T> extends Assert {
     $msg = \vsprintf($msg, $args);
 
     $value = $this->var;
-    /* HH_FIXME[4110] KeyedContainer<_, _> always has arraykey keys */
     $this->assertKeyAndValueEquals(
       $expected as KeyedContainer<_, _>,
       $value as KeyedContainer<_, _>,
@@ -345,7 +346,7 @@ class ExpectObj<T> extends Assert {
       print_type($actual),
     );
 
-    $this->assertIsSorted($actual, /* HH_FIXME[4110] */ $comparator, $msg);
+    $this->assertIsSorted($actual, $comparator, $msg);
   }
 
   /**
@@ -399,7 +400,7 @@ class ExpectObj<T> extends Assert {
     $msg = \vsprintf($msg, $args);
     $val = $this->var;
     $this->assertNotNull($val, $msg);
-    return /* HH_IGNORE_ERROR[4110] */ $val;
+    return $val as nonnull;
   }
 
   /**


### PR DESCRIPTION
 - Assert.hack
  Clarify a HH_FIXME.
  Remove a dead fixme.
 - ExpectObj.hack
  Remove some dead fixmes.
  Clarify a HH_FIXME.
  Use as nonnull to convince the typechecker.
    This code was written before is/as checks were a thing.
 - TraversableContains.hack
  Clarify a HH_FIXME