### PR TITLE
Sprintf has been updated to take ?arraykey for %s

### DIFF
--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\FBExpect;
 
+use namespace HH\Lib\{Str, Vec};
+
 class ExpectObj<T> extends Assert {
   public function __construct(private T $var) {}
 
@@ -524,17 +526,22 @@ class ExpectObj<T> extends Assert {
     $msg = \vsprintf($msg, $args);
     $e = $this->tryCallWithArgsReturnException(varray[], \Exception::class);
     if ($e !== null) {
-      $msg = \sprintf(
+      $msg = Str\format(
         "%s was thrown: %s\n%s",
         \get_class($e),
         $msg,
-        \implode("\n  ", \array_map(
+        Vec\map(
+          $e->getTrace(),
           $t ==> {
             $t = $t as KeyedContainer<_, _>;
-            return \sprintf('%s: %s', idx($t, 'file'), idx($t, 'line'));
+            return Str\format(
+              '%s: %d',
+              idx($t, 'file') as ?string ?? '<no file>',
+              idx($t, 'line') as ?int ?? -1,
+            );
           },
-          $e->getTrace(),
-        )),
+        )
+          |> Str\join($$, "\n  "),
       );
     }
     $this->assertNull($e, $msg);


### PR DESCRIPTION
https://github.com/facebook/hhvm/commit/354c0368673e6037f44ed3d5aeee9639fe7ca20d

This caused a typeerror where `mixed` assign to `?arraykey` failed.
I upgraded to `Str\format()` and `Vec\map()` while I was at it.