### PR TITLE
Let ExpectObj be non-final for backward compatibility

### DIFF
--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -14,7 +14,8 @@ use namespace HH\Lib\{C, Str, Vec};
 use type HH\Lib\Ref;
 use type Facebook\HackTest\ExpectationFailedException;
 
-final class ExpectObj<T> extends Assert {
+/* HHAST_IGNORE_ERROR[FinalOrAbstractClass] Intentional non-final for backward compatibility */
+class ExpectObj<T> extends Assert {
   public function __construct(private T $var) {}
 
   /**************************************


### PR DESCRIPTION
It seems that there are use cases to extend `ExpectObj`
 https://github.com/Atry/hhast/runs/6761770359?check_suite_focus=true

Making it be final is not safe.