### PR TITLE
Unsortable has same contents as

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,12 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu-20.04 ]
         hhvm:
           - '4.128'
-          - latest
-          - nightly
-    runs-on: ${{matrix.os}}-latest
+          - '4.153'
+          - '4.168'
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Create branch for version alias

--- a/src/Assert.hack
+++ b/src/Assert.hack
@@ -746,7 +746,7 @@ abstract class Assert {
   }
 
   /**
-   * Each returned vec, expect for the last one is naively sortable.
+   * Each returned vec, except for the last one is naively sortable.
    * The number of nulls is returned, since there is only one value of this type.
    * Returning a `vec<null>`, just to sort and count them would be rather silly...
    */

--- a/src/ExpectObj.hack
+++ b/src/ExpectObj.hack
@@ -16,7 +16,7 @@ use type Facebook\HackTest\ExpectationFailedException;
 
 /* HHAST_IGNORE_ERROR[FinalOrAbstractClass] Intentional non-final for backward compatibility */
 class ExpectObj<T> extends Assert {
-  public function __construct(private T $var) {}
+  public function __construct(private T $var)[] {}
 
   /**************************************
    **************************************
@@ -53,6 +53,22 @@ class ExpectObj<T> extends Assert {
   ): void {
     $msg = \vsprintf($msg, $args);
     $this->assertEquals($expected, $this->var, $msg);
+  }
+
+  public function toBeOfType<<<__Enforceable>> reify Treified>(
+    string $msg = '',
+    mixed ...$args
+  )[]: Treified {
+    $v = $this->var;
+    if (!$v is Treified) {
+      throw new ExpectationFailedException(Str\format(
+        "%s\nFailed to assert that %s was of the expected type.",
+        \vsprintf($msg, $args),
+        \var_export_pure($v),
+      ));
+    }
+
+    return $v;
   }
 
   /**

--- a/src/expect.hack
+++ b/src/expect.hack
@@ -23,6 +23,6 @@ namespace Facebook\FBExpect;
  *   - Function Call Assertions
  *   - Function Exception Assertions
  */
-function expect<T>(T $obj): ExpectObj<T> {
+function expect<T>(T $obj)[]: ExpectObj<T> {
   return new ExpectObj($obj);
 }


### PR DESCRIPTION
fixes #30
fixes #37

Fixes:
 - Fixes Ci
 - `->toHaveSameContents()` for unorderable sequences
 - Adds `->toBeOfType<T>()`